### PR TITLE
Minor test fixups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,4 +52,4 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
 
       - run: poetry install
-      - run: poetry run pytest -vv --cov --cov-report=term-missing
+      - run: poetry run pytest -vv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ importlib-resources = {version = "^5.12.0", python = "<3.9"}
 pytest = "^7.1.3"
 pytest-cov = "^4.0.0"
 
+[tool.pytest.ini_options]
+pythonpath = "src"
+addopts = "--cov --cov-report=html --cov-report=term-missing"
+required_plugins = "pytest-cov>=4.0.0"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-addopts = --tb=native --cov=src --cov-report=html src --junitxml=report.xml
-junit_family = xunit1

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -82,8 +82,10 @@ def test_missing_common_official_use_same():
     aruba = pycountry.countries.get(alpha_2="AW")
     assert aruba.alpha_2 == "AW"
     assert aruba.name == "Aruba"
-    assert aruba.official_name == "Aruba"
-    assert aruba.common_name == "Aruba"
+    with pytest.warns(UserWarning, match="official_name not found"):
+        assert aruba.official_name == "Aruba"
+    with pytest.warns(UserWarning, match="common_name not found"):
+        assert aruba.common_name == "Aruba"
 
 
 def test_missing_common_official_use_different():

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -323,6 +323,11 @@ def test_remove_entry():
     assert pycountry.countries.get(alpha_2="DE") is None
 
 
+def test_remove_non_existent_entry():
+    with pytest.raises(KeyError, match="not found"):
+        pycountry.countries.remove_entry(name="Not A Real Country")
+
+
 def test_no_results_lookup_error():
     try:
         import importlib_resources  # type: ignore
@@ -441,28 +446,6 @@ def test_all_subdivisions_have_name_attribute():
     all_have_name_attr = all(has_name_attr)
 
     assert all_have_name_attr
-
-
-def test_remove_countries():
-    # Test case 1: Removing an existing entry
-    kw1 = {"name": "United States"}
-    try:
-        pycountry.countries.remove_entry(**kw1)
-    except KeyError as e:
-        assert False, f"Unexpected KeyError for 'United States': {e}"
-
-    # Test case 2: Removing a non-existing entry
-    kw2 = {"name": "Non Existent Country"}
-    try:
-        pycountry.countries.remove_entry(**kw2)
-    except KeyError as e:
-        assert "not found and cannot be removed" in str(
-            e
-        )  # Check the error message
-    else:
-        assert (
-            False
-        ), "Expected KeyError for 'Non Existent Country', but no exception was raised"
 
 
 def test_subdivisions_with_missing_parents():

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -181,8 +181,7 @@ def test_locales():
     german = gettext.translation(
         "iso3166-1", pycountry.LOCALES_DIR, languages=["de"]
     )
-    german.install()
-    assert _("Germany") == "Deutschland"
+    assert german.gettext("Germany") == "Deutschland"
 
 
 def test_removed_countries():

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -282,6 +282,10 @@ def test_subdivision_empty_list():
 
 
 def test_has_version_attribute():
+    try:
+        _importlib_metadata.distribution("pycountry")
+    except _importlib_metadata.PackageNotFoundError:
+        pytest.skip("pycountry not installed correctly, you're on your own")
     assert pycountry.__version__ != "n/a"
     assert len(pycountry.__version__) >= 5
     assert "." in pycountry.__version__

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -10,13 +10,6 @@ import pycountry
 import pycountry.db
 
 
-@pytest.fixture(autouse=True, scope="session")
-def logging():
-    import logging
-
-    logging.basicConfig(level=logging.DEBUG)
-
-
 def test_country_list():
     assert len(pycountry.countries) == 249
     assert isinstance(list(pycountry.countries)[0], pycountry.db.Data)

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -376,16 +376,16 @@ def test_subdivision_partial_match():
     assert results[0].name == "Massachusetts"
 
 
-def non_country_attribute_error(self):
-    with self.assertRaises(AttributeError):
-        english = pycountry.languages.get(name="English")
-        result = english.official_name
+def test_non_country_attribute_error():
+    english = pycountry.languages.get(name="English")
+    with pytest.raises(AttributeError):
+        english.official_name
 
 
-def country_attribute_error(self):
-    with self.assertRaises(AttributeError):
-        canada = pycountry.countries.get(alpha_2="CA")
-        result = canada.maple_syrup
+def test_country_attribute_error():
+    canada = pycountry.countries.get(alpha_2="CA")
+    with pytest.raises(AttributeError):
+        canada.maple_syrup
 
 
 def test_with_accents():

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py3{8,9,10,11,12},clean,report
 [testenv]
 deps = pytest
    pytest-cov
-commands = pytest --cov --cov-append --cov-report=term-missing
+commands = pytest --cov-append
 depends =
 	py3{8,9,10,11,12}: clean
 	report: py3{8,9,10,11,12}


### PR DESCRIPTION
- Catch and assert warnings in tests
- Activate mis-named tests, rewrite them for pytest
- Avoid polluting builtins with gettext.install
- Remove unused logging fixture

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pycountry/pycountry/194)
<!-- Reviewable:end -->
