### PR TITLE
Added return at first to fuzzy search

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -54,7 +54,7 @@ class ExistingCountries(pycountry.db.Database):
     data_class = pycountry.db.Country
     root_key = "3166-1"
 
-    def search_fuzzy(self, query: str) -> List[Type["ExistingCountries"]]:
+    def search_fuzzy(self, query: str, return_first: bool = False) -> List[Type["ExistingCountries"]]:
         query = remove_accents(query.strip().lower())
 
         # A country-code to points mapping for later sorting countries
@@ -68,6 +68,8 @@ class ExistingCountries(pycountry.db.Database):
         # Prio 1: exact matches on country names
         try:
             add_result(self.lookup(query), 50)
+            if return_first:
+                return [self.get(alpha_2=list(results.keys())[0])]
         except LookupError:
             pass
 
@@ -77,6 +79,8 @@ class ExistingCountries(pycountry.db.Database):
         )
         for candidate in match_subdivions:
             add_result(candidate.country, 49)
+            if return_first:
+                return [self.get(alpha_2=list(results.keys())[0])]
 
         # Prio 3: partial matches on country names
         for candidate in self:
@@ -96,6 +100,8 @@ class ExistingCountries(pycountry.db.Database):
                         add_result(
                             candidate, max([5, 30 - (2 * v.find(query))])
                         )
+                        if return_first:
+                            return [self.get(alpha_2=list(results.keys())[0])]
                         break
 
         # Prio 4: partial matches on subdivision names
@@ -107,6 +113,8 @@ class ExistingCountries(pycountry.db.Database):
             v = remove_accents(v.lower())
             if query in v:
                 add_result(candidate.country, max([1, 5 - v.find(query)]))
+                if return_first:
+                    return [self.get(alpha_2=list(results.keys())[0])]
 
         if not results:
             raise LookupError(query)

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -251,7 +251,7 @@ class Subdivisions(pycountry.db.Database):
 
         return matching_candidates
 
-    def search_fuzzy(self, query: str) -> List[Type["Subdivisions"]]:
+    def search_fuzzy(self, query: str, return_first: bool = False) -> List[Type["Subdivisions"]]:
         query = remove_accents(query.strip().lower())
 
         # A Subdivision's code to points mapping for later sorting subdivisions
@@ -268,6 +268,8 @@ class Subdivisions(pycountry.db.Database):
         match_subdivisions = self.match(query)
         for candidate in match_subdivisions:
             add_result(candidate, 50)
+            if return_first:
+                return [self.get(code=list(results.keys())[0])]
 
         # Prio 2: partial matches on subdivision names
         partial_match_subdivisions = self.partial_match(query)
@@ -276,6 +278,8 @@ class Subdivisions(pycountry.db.Database):
             v = remove_accents(v.lower())
             if query in v:
                 add_result(candidate, max([1, 5 - v.find(query)]))
+                if return_first:
+                    return [self.get(code=list(results.keys())[0])]
 
         if not results:
             raise LookupError(query)


### PR DESCRIPTION
I added the option to return on the first result for the fuzzy search. You can use it like this:

```py
r = pycountry.countries.search_fuzzy(query, return_first=True)
```

Nothing changes, if you don't set this argument to True.

# Benchmarking results

## return_first=False

```
average: 0.013234267592157109 seconds
numbers called: 12663
total duration: 167.58553051948547 seconds
```

## return_first=True

```
average: 0.00018396609280233898 seconds
numbers called: 89187
total duration: 16.407383918762207 seconds
```

## Results

```
avr_slow / avr_fast = speedup
0.013234267592157109 seconds / 0.00018396609280233898 seconds = 71.938624072
```

The the fuzzy search is 71 times slower if not returning on first match using my dataset.  
The dataset I tested with is real user data, but pretty clean.