### PR TITLE
Update pyproject.toml to use a valid SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
 	"Nate Schimmoller <nschimmo@gmail.com>",
 	"Zachary Ware <zachary.ware@gmail.com>",
 	]
-license = "(LGPL-2.1-only)"
+license = "LGPL-2.1-only"
 readme = "README.rst"
 repository = "https://github.com/flyingcircusio/pycountry"
 keywords = [ "country", "subdivision", "language", "currency", "iso", "3166", "639", "4217", "15924", "3166-1","3166-2", "3166-3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
 	"Nate Schimmoller <nschimmo@gmail.com>",
 	"Zachary Ware <zachary.ware@gmail.com>",
 	]
-license = "LGPL 2.1"
+license = "(LGPL-2.1-only)"
 readme = "README.rst"
 repository = "https://github.com/flyingcircusio/pycountry"
 keywords = [ "country", "subdivision", "language", "currency", "iso", "3166", "639", "4217", "15924", "3166-1","3166-2", "3166-3"]


### PR DESCRIPTION
According to [PEP 621](https://peps.python.org/pep-0621/) the `license` field in `pyproject.toml` is a list. Even though at the moment the content of the license string is free-form, in practise PyPI expects a valid [SPDX](https://spdx.org/licenses/) license identifier. Currently PyPI show the license metadata for [pycountry](https://pypi.org/project/pycountry/) as:

```
Meta
License: GNU Lesser General Public License v2 (LGPLv2), Other/Proprietary License (LGPL 2.1)
```

This PR fixes that by setting the license to `LGPL-2.1-only`.

Alternatively `LGPL-2.1-or-later` can be used, in which case the `classifiers` should also be updated with:
```
"License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)"
```
Unfortunately because of https://github.com/pypa/trove-classifiers/issues/17 `LGPLv2.1` is not in the [allowed classifiers](https://pypi.org/classifiers/) list.