### PR TITLE
Added Russia as a common name for Russian Federation

### DIFF
--- a/src/pycountry/databases/iso3166-1.json
+++ b/src/pycountry/databases/iso3166-1.json
@@ -1461,6 +1461,7 @@
     {
       "alpha_2": "RU",
       "alpha_3": "RUS",
+      "common_name": "Russia",
       "flag": "🇷🇺",
       "name": "Russian Federation",
       "numeric": "643"


### PR DESCRIPTION
Added Russia as a common name for Russian Federation, as it's the common name everyone refers to the Russian Federation as.