### PR TITLE
Partially revert #175/#134 (#192)

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,8 +1,11 @@
 Changes
 =======
 
-23.12.11.dev0 (Unreleased)
---------------------------
+24.6.1.dev0 (Unreleased)
+------------------------
+
+- **Breaking change**: Reverted the fallback to name when country common_name
+  or official_name attributes not available, which was added in 23.12.11.
 
 - Fixed import of importlib_metadata to importlib.metadata
 
@@ -15,8 +18,8 @@ Changes
 23.12.11 (2023-12-11)
 ---------------------
 
-- Added fallback to name when common_name or official_name country attributes
-  are missing
+- ~~Added fallback to name when common_name or official_name country attributes
+  are missing~~ Reverted in v24.6.1.
 
 - Added support for adding and removing country records, as well as casting to
   dict

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import threading
-import warnings
 from typing import Any, Iterator, List, Optional, Type, Union
 
 logger = logging.getLogger("pycountry.db")
@@ -14,7 +13,7 @@ class Data:
     def __getattr__(self, key):
         if key in self._fields:
             return self._fields[key]
-        raise AttributeError()
+        raise AttributeError(key)
 
     def __setattr__(self, key: str, value: str) -> None:
         if key != "_fields":
@@ -36,26 +35,7 @@ class Data:
 
 
 class Country(Data):
-    def __getattr__(self, key):
-        if key in ("common_name", "official_name"):
-            # First try to get the common_name or official_name
-            value = self._fields.get(key)
-            if value is not None:
-                return value
-            # Fall back to name if common_name or official_name is not found
-            name = self._fields.get("name")
-            if name is not None:
-                warning_message = (
-                    f"Country's {key} not found. Country name provided instead."
-                )
-                warnings.warn(warning_message, UserWarning)
-                return name
-            raise AttributeError()
-        else:
-            # For other keys, simply return the value or raise an error
-            if key in self._fields:
-                return self._fields[key]
-            raise AttributeError()
+    pass
 
 
 class Subdivision(Data):

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -78,14 +78,14 @@ def test_germany_has_all_attributes(countries):
     assert germany.official_name == "Federal Republic of Germany"
 
 
-def test_missing_common_official_use_same(countries):
+def test_missing_common_official(countries):
     aruba = pycountry.countries.get(alpha_2="AW")
     assert aruba.alpha_2 == "AW"
     assert aruba.name == "Aruba"
-    with pytest.warns(UserWarning, match="official_name not found"):
-        assert aruba.official_name == "Aruba"
-    with pytest.warns(UserWarning, match="common_name not found"):
-        assert aruba.common_name == "Aruba"
+    with pytest.raises(AttributeError, match="official_name"):
+        aruba.official_name
+    with pytest.raises(AttributeError, match="common_name"):
+        aruba.common_name
 
 
 def test_missing_common_official_use_different(countries):


### PR DESCRIPTION
The warning made this feature annoying to use, and ignoring the warning
made it impossible to tell if you got the real `common_name` or
`official_name`.  We'll come back with a better API later.
