### PR TITLE
Adds `country_code` to subdivision search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,10 +213,11 @@ index:
    57
 
 Similar to countries, the ``search_fuzzy`` method has been implemented
-for subdivisions to facilitate finding relevant subdivision entries.
-This method includes unicode normalization for accents and prioritizes
-matches on subdivision names. The search algorithm is designed to return
-more relevant matches first:
+for subdivisions to facilitate finding relevant subdivision entries. It
+accepts an optional argument with a ``country_code``. This method
+includes unicode normalization for accents and prioritizes matches on
+subdivision names. The search algorithm is designed to return more
+relevant matches first:
 
 This method is especially useful for cases where the exact name or code
 of the subdivision is not known.
@@ -228,6 +229,11 @@ of the subdivision is not known.
      Subdivision(code='GB-ERY', country_code='GB', name='East Riding of Yorkshire', parent='GB-ENG', parent_code='GB-GB-ENG', type='Unitary authority')
      Subdivision(code='GB-NYK', country_code='GB', name='North Yorkshire', parent='GB-ENG', parent_code='GB-GB-ENG', type='Two-tier county')
      Subdivision(code='US-NY', country_code='US', name='New York', parent_code=None, type='State')]
+
+   >>> pycountry.subdivisions.search_fuzzy('York', country_code='GB')
+     [Subdivision(code='GB-YOR', country_code='GB', name='York', parent='GB-ENG', parent_code='GB-GB-ENG', type='Unitary authority')
+     Subdivision(code='GB-ERY', country_code='GB', name='East Riding of Yorkshire', parent='GB-ENG', parent_code='GB-GB-ENG', type='Unitary authority')
+     Subdivision(code='GB-NYK', country_code='GB', name='North Yorkshire', parent='GB-ENG', parent_code='GB-GB-ENG', type='Two-tier county')]
 
 *********************
  Scripts (ISO 15924)

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -216,10 +216,14 @@ class Subdivisions(pycountry.db.Database):
                 return []
         return subdivisions
 
-    def match(self, query):
+    def match(self, query, country_code: str = ""):
         query = remove_accents(query.strip().lower())
+        country_code = country_code.upper()
         matching_candidates = []
         for candidate in subdivisions:
+            if country_code and country_code != candidate.country_code:
+                continue
+
             for v in candidate._fields.values():
                 if v is not None:
                     v = remove_accents(v.lower())
@@ -232,10 +236,14 @@ class Subdivisions(pycountry.db.Database):
 
         return matching_candidates
 
-    def partial_match(self, query):
+    def partial_match(self, query, country_code: str = ""):
         query = remove_accents(query.strip().lower())
         matching_candidates = []
+        country_code = country_code.upper()
         for candidate in subdivisions:
+            if country_code and country_code != candidate.country_code:
+                continue
+
             v = candidate._fields.get("name")
             v = remove_accents(v.lower())
             if query in v:
@@ -243,7 +251,9 @@ class Subdivisions(pycountry.db.Database):
 
         return matching_candidates
 
-    def search_fuzzy(self, query: str) -> List[Type["Subdivisions"]]:
+    def search_fuzzy(
+        self, query: str, country_code: str = ""
+    ) -> List[Type["Subdivisions"]]:
         query = remove_accents(query.strip().lower())
 
         # A Subdivision's code to points mapping for later sorting subdivisions
@@ -257,12 +267,14 @@ class Subdivisions(pycountry.db.Database):
             results[subdivision.code] += points
 
         # Prio 1: exact matches on subdivision names
-        match_subdivisions = self.match(query)
+        match_subdivisions = self.match(query, country_code=country_code)
         for candidate in match_subdivisions:
             add_result(candidate, 50)
 
         # Prio 2: partial matches on subdivision names
-        partial_match_subdivisions = self.partial_match(query)
+        partial_match_subdivisions = self.partial_match(
+            query, country_code=country_code
+        )
         for candidate in partial_match_subdivisions:
             v = candidate._fields.get("name")
             v = remove_accents(v.lower())

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -359,21 +359,51 @@ def test_no_results_lookup_error(countries):
 
 
 def test_subdivision_fuzzy_search_match():
+    # without country
     results = pycountry.subdivisions.search_fuzzy("Alabama")
     assert len(results) == 1
     assert results[0].name == "Alabama"
 
+    # with country and a match
+    results = pycountry.subdivisions.search_fuzzy(
+        "Centre-Nord", country_code="BF"
+    )
+    assert len(results) == 1
+    assert results[0].name == "Centre-Nord"
+
 
 def test_subdivision_fuzzy_search_partial_match():
+    # without country
     results = pycountry.subdivisions.search_fuzzy("Massachusett")
     assert len(results) == 1
     assert results[0].name == "Massachusetts"
 
+    # with country and a match
+    results = pycountry.subdivisions.partial_match(
+        "Centre-Nord", country_code="BF"
+    )
+    assert len(results) == 1
+    assert results[0].name == "Centre-Nord"
+
+    # with country and no match
+    results = pycountry.subdivisions.partial_match("Alabama", country_code="BF")
+    assert not results
+
 
 def test_subdivision_match():
+    # without country
     results = pycountry.subdivisions.match("Alabama")
     assert len(results) == 1
     assert results[0].name == "Alabama"
+
+    # with country and a match
+    results = pycountry.subdivisions.match("Centre", country_code="BF")
+    assert len(results) == 1
+    assert results[0].name == "Centre"
+
+    # with country and no match
+    results = pycountry.subdivisions.match("Alabama", country_code="BF")
+    assert not results
 
 
 def test_subdivision_partial_match():


### PR DESCRIPTION
This PR suggests adding a `code_country` to the search API for subdivision:
* `search_fuzzy`
* `match`
* `partial_match`

This allows users that know which country to expect subdivisions from to have a better API to list only relevant results.