### PR TITLE
Fix issue #247 - Unknown country code returning unusual behavior

### DIFF
--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -155,7 +155,7 @@ class Database:
 
     @lazy_load
     def get(
-        self, *, default: Optional[Any] = None, **kw: Optional[str]
+        self, *, default: Optional[Any] = [], **kw: Optional[str]
     ) -> Optional[Any]:
         if len(kw) != 1:
             raise TypeError("Only one criteria may be given")

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -229,7 +229,7 @@ def test_get(countries):
     with pytest.raises(TypeError):
         c.get(alpha_2="DE", alpha_3="DEU")
     assert c.get(alpha_2="DE") == c.get(alpha_3="DEU")
-    assert c.get(alpha_2="Foo") is None
+    assert c.get(alpha_2="Foo") == []
     tracer = object()
     assert c.get(alpha_2="Foo", default=tracer) is tracer
 
@@ -278,7 +278,7 @@ def test_subdivision_empty_list():
     s = pycountry.subdivisions
     assert len(s.get(country_code="DE")) == 16
     assert len(s.get(country_code="JE")) == 0
-    assert s.get(country_code="FOOBAR") is None
+    assert s.get(country_code="FOOBAR") == []
 
 
 def test_has_version_attribute():
@@ -314,7 +314,7 @@ def test_is_instance_of_currency():
 
 
 def test_add_entry(countries):
-    assert pycountry.countries.get(alpha_2="XK") is None
+    assert pycountry.countries.get(alpha_2="XK") == []
 
     pycountry.countries.add_entry(
         alpha_2="XK", alpha_3="XXK", name="Kosovo", numeric="926"
@@ -325,11 +325,11 @@ def test_add_entry(countries):
 
 
 def test_remove_entry(countries):
-    assert pycountry.countries.get(alpha_2="DE") is not None
+    assert pycountry.countries.get(alpha_2="DE") != []
 
     pycountry.countries.remove_entry(alpha_2="DE")
 
-    assert pycountry.countries.get(alpha_2="DE") is None
+    assert pycountry.countries.get(alpha_2="DE") == []
 
 
 def test_remove_non_existent_entry():


### PR DESCRIPTION
Issue #247 showed unusual behavior when using the get function, where the return was none instead of an empty list. After having checked the code, I noticed that the problem was in the Database.get() method:

Specifically, the default variable, which is defined as a list, was defaulted as None, which, when the function cannot find the correct object, was returned. Given that the function is defined as returning a list, it made sense to make the change to an empty list as the default value. 

```python
@lazy_load
  def get(
      self, *, default: Optional[Any] = None, **kw: Optional[str]
  ) -> Optional[Any]:
      if len(kw) != 1:
          raise TypeError("Only one criteria may be given")
      field, value = kw.popitem()
      if not isinstance(value, str):
          raise LookupError()
      # Normalize for case-insensitivity
      value = value.lower()
      index = self.indices[field]
      try:
          return index[value]
      except KeyError:
          # Pythonic APIs implementing     get() shouldn't raise KeyErrors.
          # Those are a bit unexpected and they should rather support
          # returning `None` by default and allow customization.
          return default
```