### PR TITLE
add parent to MZ-MPM (#250)

### DIFF
--- a/src/pycountry/databases/iso3166-2.json
+++ b/src/pycountry/databases/iso3166-2.json
@@ -17690,6 +17690,7 @@
     {
       "code": "MZ-MPM",
       "name": "Maputo",
+      "parent": "MZ-L",
       "type": "City"
     },
     {


### PR DESCRIPTION
Resolves the missing parent of Maputo City (MZ-MPM) #250 