### PR TITLE
Fix return type annotation for ExistingCountries.search_fuzzy

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -54,7 +54,7 @@ class ExistingCountries(pycountry.db.Database):
     data_class = pycountry.db.Country
     root_key = "3166-1"
 
-    def search_fuzzy(self, query: str) -> List[Type["ExistingCountries"]]:
+    def search_fuzzy(self, query: str) -> List[pycountry.db.Country]:
         query = remove_accents(query.strip().lower())
 
         # A country-code to points mapping for later sorting countries


### PR DESCRIPTION
@zware, as suggested [here](https://github.com/pycountry/pycountry/issues/211#issuecomment-2361346963), I have gone ahead and extracted the minimum change to correct the return type annotation of `search_fuzzy` and thus fix #211.

If you are ok with that, I would also like to open further pull requests cherry-picking some of the changes in #193 to make them easier to review and merge.