### PR TITLE
Avoid losing the type when decorating a method with lazy_load

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -114,7 +114,7 @@ class ExistingCountries(pycountry.db.Database):
             # points but ascending on the country code.
             for x in sorted(results.items(), key=lambda x: (-x[1], x[0]))
         ]
-        return cast(List[pycountry.db.Country], sorted_results)
+        return cast(list[pycountry.db.Country], sorted_results)
 
 
 class HistoricCountries(ExistingCountries):

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -4,7 +4,7 @@ import os.path
 import unicodedata
 from importlib import metadata as _importlib_metadata
 from importlib import resources as _importlib_resources
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import pycountry.db
 

--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -4,7 +4,7 @@ import os.path
 import unicodedata
 from importlib import metadata as _importlib_metadata
 from importlib import resources as _importlib_resources
-from typing import Optional
+from typing import List, Optional, cast
 
 import pycountry.db
 
@@ -114,7 +114,7 @@ class ExistingCountries(pycountry.db.Database):
             # points but ascending on the country code.
             for x in sorted(results.items(), key=lambda x: (-x[1], x[0]))
         ]
-        return sorted_results
+        return cast(List[pycountry.db.Country], sorted_results)
 
 
 class HistoricCountries(ExistingCountries):

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -2,7 +2,7 @@ import json
 import logging
 import threading
 from collections.abc import Iterator
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 logger = logging.getLogger("pycountry.db")
 
@@ -43,14 +43,17 @@ class Subdivision(Data):
     pass
 
 
-def lazy_load(f):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def lazy_load(f: F) -> F:
     def load_if_needed(self, *args, **kw):
         if not self._is_loaded:
             with self._load_lock:
                 self._load()
         return f(self, *args, **kw)
 
-    return load_if_needed
+    return cast(F, load_if_needed)
 
 
 class Database:
@@ -147,7 +150,7 @@ class Database:
                 del index[value]
 
     @lazy_load
-    def __iter__(self) -> Iterator["Database"]:
+    def __iter__(self) -> Iterator[Any]:
         return iter(self.objects)
 
     @lazy_load
@@ -175,7 +178,7 @@ class Database:
             return default
 
     @lazy_load
-    def lookup(self, value: str) -> type:
+    def lookup(self, value: str) -> Any:
         if not isinstance(value, str):
             raise LookupError()
 


### PR DESCRIPTION
I also fixed the return types of some Database methods which were incorrect. For these, I used Any to keep the current changeset minimal.

I will submit a follow-up pull request to make Database generic over the type of data and provide better return types.