### PR TITLE
Additional type-hinting for standard country types

### DIFF
--- a/src/pycountry/__init__.py
+++ b/src/pycountry/__init__.py
@@ -4,7 +4,7 @@ import os.path
 import unicodedata
 from importlib import metadata as _importlib_metadata
 from importlib import resources as _importlib_resources
-from typing import Optional, cast
+from typing import Generic, Optional, cast
 
 import pycountry.db
 
@@ -39,13 +39,10 @@ def remove_accents(input_str: str) -> str:
     return output_str
 
 
-class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
+class Countries(Generic[pycountry.db.F], pycountry.db.Database[pycountry.db.F]):
     """Provides access to an ISO 3166 database (Countries)."""
 
-    data_class = pycountry.db.Country
-    root_key = "3166-1"
-
-    def search_fuzzy(self, query: str) -> list[pycountry.db.Country]:
+    def search_fuzzy(self, query: str) -> list[pycountry.db.F]:
         query = remove_accents(query.strip().lower())
 
         # A country-code to points mapping for later sorting countries
@@ -114,14 +111,21 @@ class ExistingCountries(pycountry.db.Database[pycountry.db.Country]):
             # points but ascending on the country code.
             for x in sorted(results.items(), key=lambda x: (-x[1], x[0]))
         ]
-        return cast(list[pycountry.db.Country], sorted_results)
+        return cast(list[pycountry.db.F], sorted_results)
 
 
-class HistoricCountries(ExistingCountries):
+class ExistingCountries(Countries[pycountry.db.ExistingCountry]):
+    """Provides access to an ISO 3166 database (Countries)."""
+
+    data_class = pycountry.db.ExistingCountry
+    root_key = "3166-1"
+
+
+class HistoricCountries(Countries[pycountry.db.HistoricCountry]):
     """Provides access to an ISO 3166-3 database
     (Countries that have been removed from the standard)."""
 
-    data_class = pycountry.db.Country
+    data_class = pycountry.db.HistoricCountry
     root_key = "3166-3"
 
 

--- a/src/pycountry/db.py
+++ b/src/pycountry/db.py
@@ -22,7 +22,9 @@ class Data:
         super().__setattr__(key, value)
 
     def __repr__(self) -> str:
-        cls_name = self.__class__.__name__
+        return self.__repr_common__(self.__class__.__name__)
+
+    def __repr_common__(self, cls_name: str) -> str:
         fields = ", ".join("%s=%r" % i for i in sorted(self._fields.items()))
         return f"{cls_name}({fields})"
 
@@ -35,8 +37,31 @@ class Data:
             yield field, getattr(self, field)
 
 
+
+
 class Country(Data):
-    pass
+    def __repr__(self) -> str:
+        return self.__repr_common__("Country")
+
+
+class ExistingCountry(Country):
+    alpha_2: str
+    alpha_3: str
+    flag: str
+    name: str
+    numeric: str
+    official_name: Optional[str]
+    common_name: Optional[str]
+
+
+class HistoricCountry(Country):
+    alpha_2: str
+    alpha_3: str
+    alpha_4: str
+    name: str
+    withdrawal_date: str
+    numeric: Optional[str]
+    comment: Optional[str]
 
 
 class Subdivision(Data):

--- a/src/pycountry/tests/test_general.py
+++ b/src/pycountry/tests/test_general.py
@@ -303,8 +303,9 @@ def test_is_instance_of_language():
 
 def test_is_instance_of_country(countries):
     united_states = pycountry.countries.get(alpha_2="US")
+    assert isinstance(united_states, pycountry.db.Country)
     class_name = united_states.__class__.__name__
-    assert class_name == "Country"
+    assert class_name == "ExistingCountry"
 
 
 def test_is_instance_of_subdivision():


### PR DESCRIPTION
# Issue
I use type checking tools like MyPy extensively in my day-to-day work, and the lack of complete type hinting for the `Country` objects from pycountry is a minor, albeit consistent, bother. Therefore I put this PR together in the hopes that you're amenable to enhancing this

For the record, I'm not stuck on any aspects of this implementation (this is just a quick stab at it), so I'm happy to adjust it according to your preferences

# Outcome
The outcome of this is that tools like mypy will understand that objects returned from `pycountry.countries.get(...)` should always have a, for example, `alpha_2` string property, but will only possibly have a `common_name` property. 

Functionally, nothing should change about how the module works

# Proposed Changes
This PR introduces two subclasses of `Country`, `ExistingCountry` and `HistoricCountry`, which have basic type hints derived from the objects currently in `iso3166-1.json` and `iso3166-3.json`, respectively. If a parameter was present in all objects, then the type hint is `str`, and if it was missing in at least one object then the type hint is `Optional[str]`

Additionally this PR turns the `Countries` class (previously `ExistingCountries`) into a generic over `db.F`, which is then subclassed by `ExistingCountries` and `HistoricCountries` using their respective Country type.

All behavior should remain the same, with special attention that the `repr` of any `Country` object should stay as it is currently. However the one exception is that direct calls to `[object].__class__.__name__` will change. This is updated in the test `test_is_instance_of_country`